### PR TITLE
fix: move env variables to job level

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -15,6 +15,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      VITE_AWS_KEY: ${{ secrets.VITE_AWS_KEY }}
+      VITE_AWS_SECRET: ${{ secrets.VITE_AWS_SECRET }}
+      VITE_AUTH_URL: ${{ secrets.VITE_AUTH_URL }}
+      VITE_PROJECT_ID: ${{ secrets.VITE_PROJECT_ID }}
+      VITE_CARGO_ENDPOINT: ${{ secrets.VITE_CARGO_ENDPOINT }}
+      VITE_S3_ENDPOINT: ${{ secrets.VITE_S3_ENDPOINT }}
     steps:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
@@ -26,13 +33,6 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
-        env:
-          VITE_AWS_KEY: ${{ secrets.VITE_AWS_KEY }}
-          VITE_AWS_SECRET: ${{ secrets.VITE_AWS_SECRET }}
-          VITE_AUTH_URL: ${{ secrets.VITE_AUTH_URL }}
-          VITE_PROJECT_ID: ${{ secrets.VITE_PROJECT_ID }}
-          VITE_CARGO_ENDPOINT: ${{ secrets.VITE_CARGO_ENDPOINT }}
-          VITE_S3_ENDPOINT: ${{ secrets.VITE_S3_ENDPOINT }}
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
DockerHub image is built from the `Dockerfile`. The build which will be deployed cannot read the env variable under `npm run build`.