### PR TITLE
feat: add sorting by table column

### DIFF
--- a/src/components/EnhancedTableHead.tsx
+++ b/src/components/EnhancedTableHead.tsx
@@ -1,0 +1,40 @@
+import { TableCell, TableHead, TableRow, TableSortLabel } from "@mui/material";
+
+type Order = 'asc' | 'desc';
+
+interface EnhancedTableProps {
+    onRequestSort: (event: React.MouseEvent<unknown>, property: string) => void;
+    columns: { label: string, id: string }[];
+    sortableIds: string[];
+    order: Order;
+    orderBy: string;
+}
+
+function EnhancedTableHead(props: EnhancedTableProps) {
+    const { columns, sortableIds, order, orderBy } = props;
+    const sortableIdsSet = new Set(sortableIds);
+
+    const createSortHandler = (property: string) => (event: React.MouseEvent<unknown>) => {
+        props.onRequestSort(event, property);
+    }
+
+    return (
+        <TableHead>
+            <TableRow>
+                {columns.map((column) => (
+                    <TableCell key={column.id}>
+                        {sortableIdsSet.has(column.id) ? 
+                            <TableSortLabel
+                                active={orderBy === column.id}
+                                direction={orderBy === column.id ? order : 'asc'}
+                                onClick={createSortHandler(column.id)}
+                            >
+                                {column.label}
+                            </TableSortLabel> : column.label}
+                    </TableCell>) )}
+            </TableRow>
+        </TableHead>
+    );
+}
+
+export default EnhancedTableHead;


### PR DESCRIPTION
- Created a generic sortable table header. It can be used to sort other columns or future columns by creating your own sorting handler. Then, add the column id to sortableIds through `props`.
- Ascending order by default.